### PR TITLE
Add workflow rules for adding synths

### DIFF
--- a/.cursor/rules/workflows/adding-synths.mdc
+++ b/.cursor/rules/workflows/adding-synths.mdc
@@ -1,0 +1,83 @@
+# Adding Synths - Workflow Rules
+
+## Step 1: Prepare the Environment
+**✅ ALWAYS register built‑in synths first**
+```javascript
+import { registerSynthSounds } from 'superdough';
+registerSynthSounds();
+```
+
+## Step 2: Define the Handler
+**✅ ALWAYS implement a WebAudio graph**
+```javascript
+import {
+  registerSound,
+  getAudioContext,
+  gainNode,
+  getADSRValues,
+  getParamADSR,
+  webAudioTimeout,
+  midiToFreq
+} from 'superdough';
+
+registerSound('organ', (begin, params, onended) => {
+  const ac = getAudioContext();
+  const frequency = midiToFreq(params.note || 60);
+  const { duration, harmonics = [1, 0.5, 0.25, 0.125] } = params;
+
+  const mix = gainNode(1);
+  const env = gainNode(1);
+  mix.connect(env);
+
+  const oscillators = harmonics.map((amp, i) => {
+    const osc = ac.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.value = frequency * (i + 1);
+    osc.connect(gainNode(amp)).connect(mix);
+    osc.start(begin);
+    return osc;
+  });
+
+  const [a, d, s, r] = getADSRValues([
+    params.attack,
+    params.decay,
+    params.sustain,
+    params.release
+  ], 'linear', [0.01, 0.1, 0.8, 0.3]);
+  const holdEnd = begin + duration;
+  const end = holdEnd + r + 0.01;
+  getParamADSR(env.gain, a, d, s, r, 0, 1, begin, holdEnd, 'linear');
+
+  const timeout = webAudioTimeout(ac, () => {
+    oscillators.forEach(o => o.disconnect());
+    mix.disconnect();
+    env.disconnect();
+    onended();
+  }, begin, end);
+
+  return {
+    node: env,
+    stop(time) {
+      timeout.stop(time);
+      oscillators.forEach(o => o.stop(time));
+    }
+  };
+}, { type: 'synth', prebake: true });
+```
+
+## Step 3: Trigger the Synth
+**✅ ALWAYS test with `superdough`**
+```javascript
+superdough({ s: 'organ', note: 'c4', duration: 1 }, 0);
+```
+
+## Step 4: Document the Synth
+**✅ ALWAYS update README and docs**
+- Briefly describe parameters and example usage
+- Link to the implementation for reference
+
+## Enforcement Rules
+- Synth handlers must clean up nodes
+- Envelope parameters should default sensibly
+- Register with `{ type: 'synth', prebake: true }`
+- Provide code comments explaining the node graph

--- a/.github/prompts/custom-synth.prompt.md
+++ b/.github/prompts/custom-synth.prompt.md
@@ -1,0 +1,65 @@
+# Custom Synth Prompt Template
+
+Create a new WebAudio synthesizer for the `superdough` engine.
+
+## Synth Name
+[NAME]
+
+**Purpose**: [Describe what the instrument should sound like]
+
+**Parameters**:
+- `note` or `freq` – base pitch of the synth
+- `duration` – note length in seconds
+- `[extra]` – [Any additional parameters]
+
+**Implementation Outline**:
+1. Register the synth with `registerSound('[NAME]', handler, { type: 'synth', prebake: true })`.
+2. Inside `handler(begin, params, onended)` build the WebAudio node graph using helpers such as `getAudioContext()` and `gainNode()`.
+3. Shape the amplitude with `getADSRValues` and `getParamADSR`.
+4. Return `{ node, stop(when) }` and disconnect all nodes in the cleanup.
+
+**Example Skeleton**:
+```javascript
+import {
+  registerSound,
+  getAudioContext,
+  gainNode,
+  getADSRValues,
+  getParamADSR,
+  webAudioTimeout
+} from 'superdough';
+
+registerSound('[NAME]', (begin, params, onended) => {
+  const ac = getAudioContext();
+  const { duration } = params;
+
+  // create oscillators and connect them
+  const env = gainNode(1);
+  const holdEnd = begin + duration;
+  const [a, d, s, r] = getADSRValues([
+    params.attack,
+    params.decay,
+    params.sustain,
+    params.release
+  ], 'linear', [0.01, 0.1, 0.8, 0.3]);
+  getParamADSR(env.gain, a, d, s, r, 0, 1, begin, holdEnd, 'linear');
+
+  const timeout = webAudioTimeout(ac, () => {
+    // disconnect nodes here
+    onended();
+  }, begin, holdEnd + r + 0.01);
+
+  return {
+    node: env,
+    stop(time) {
+      timeout.stop(time);
+      // stop oscillators
+    }
+  };
+});
+```
+
+**Usage**:
+```javascript
+superdough({ s: '[NAME]', note: 'c4', duration: 1 }, 0);
+```

--- a/claude/workflows/custom-synth.md
+++ b/claude/workflows/custom-synth.md
@@ -1,0 +1,81 @@
+# Custom Synth Workflow
+
+This workflow shows how to extend **superdough** with your own synthesiser implementations. The example below registers a simple additive `organ` synth.
+
+## 1. Load Built-in Waveforms
+```javascript
+import { registerSynthSounds } from 'superdough';
+registerSynthSounds(); // sine, square, sawtooth, triangle
+```
+
+## 2. Implement and Register Your Synth
+Use `registerSound(name, handler[, options])` to add a sound. The handler
+receives `(begin, params, onended)` and must return `{ node, stop(time) }`.
+
+```javascript
+import {
+  registerSound,
+  getAudioContext,
+  gainNode,
+  getADSRValues,
+  getParamADSR,
+  webAudioTimeout,
+  midiToFreq
+} from 'superdough';
+
+registerSound('organ', (begin, params, onended) => {
+  const ac = getAudioContext();
+  const { duration, harmonics = [1, 0.5, 0.25, 0.125] } = params;
+  const frequency = midiToFreq(params.note || 60);
+
+  // mix sums partials; envGain controls the ADSR envelope
+  const mix = gainNode(1);
+  const envGain = gainNode(1);
+  mix.connect(envGain);
+
+  // create sine oscillators for each harmonic partial
+  const voices = harmonics.map((amp, i) => {
+    const osc = ac.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.value = frequency * (i + 1);
+    osc.connect(gainNode(amp)).connect(mix);
+    osc.start(begin);
+    return osc;
+  });
+
+  const [attack, decay, sustain, release] = getADSRValues(
+    [params.attack, params.decay, params.sustain, params.release],
+    'linear',
+    [0.01, 0.1, 0.8, 0.3]
+  );
+  const holdEnd = begin + duration;
+  const end = holdEnd + release + 0.01;
+  getParamADSR(envGain.gain, attack, decay, sustain, release, 0, 1, begin, holdEnd, 'linear');
+
+  const timeout = webAudioTimeout(ac, () => {
+    voices.forEach(o => o.disconnect());
+    mix.disconnect();
+    envGain.disconnect();
+    onended();
+  }, begin, end);
+
+  return {
+    node: envGain,
+    stop: (when) => {
+      timeout.stop(when);
+      voices.forEach(o => o.stop(when));
+    }
+  };
+}, { prebake: true, type: 'synth' });
+```
+
+## 3. Trigger the Synth
+
+Once registered the instrument can be used like any other sound:
+
+```javascript
+superdough({ s: 'organ', note: 'c4', duration: 1 }, 0);
+
+// via patterns
+note('c3 e3 g3').s('organ');
+```

--- a/examples/superdough/index.html
+++ b/examples/superdough/index.html
@@ -24,6 +24,8 @@
         superdough({ s: 'hh' }, t + 0.25);
         superdough({ s: 'sd', room: 0.5 }, t + 0.5);
         superdough({ s: 'hh' }, t + 0.75);
+        // play custom organ synth
+        superdough({ s: 'organ', note: 'c4', duration: 1 }, t + 1);
       };
 
       document.getElementById('play').addEventListener('click', async () => {

--- a/packages/superdough/README.md
+++ b/packages/superdough/README.md
@@ -163,6 +163,22 @@ Initializes audio and makes sure it is playable after the first click in the doc
 You can call this function when the document loads.
 Then just make sure your first call of `superdough` happens after a click of something.
 
+## Custom synth example
+
+The synth list can be extended with your own implementations. The file
+`packages/superdough/synth.mjs` contains an example ``organ`` synth that
+mixes several sine oscillators.
+
+```javascript
+import { registerSynthSounds } from 'superdough';
+
+// register builtin waveforms
+registerSynthSounds();
+
+// the organ synth is registered automatically and can be played like this
+superdough({ s: 'organ', note: 'c4', duration: 1 }, 0);
+```
+
 ## Credits
 
 - [ZZFX](https://github.com/KilledByAPixel/ZzFX) used for synths starting with z

--- a/website/src/pages/learn/custom-synth.mdx
+++ b/website/src/pages/learn/custom-synth.mdx
@@ -1,0 +1,34 @@
+---
+title: Creating a Custom Synth
+layout: ../../layouts/MainLayout.astro
+---
+
+import { JsDoc } from '../../docs/JsDoc';
+
+# Custom synth with superdough
+
+This guide shows how to extend **superdough** with your own synthesiser. The example below registers a simple additive ``organ`` synth that mixes several sine oscillators.
+
+```javascript
+import { registerSynthSounds } from 'superdough';
+
+registerSynthSounds(); // default synths
+
+// register the organ instrument
+```
+import { registerSound } from 'superdough';
+
+registerSound('organ', (start, params, onended) => {
+  // custom implementation as shown in packages/superdough/synth.mjs
+});
+```
+
+Once registered you can use it in patterns:
+
+```javascript
+note('c3 e3 g3').s('organ')
+```
+
+The implementation lives in `packages/superdough/synth.mjs` and is heavily commented for educational purposes.
+
+<JsDoc client:idle name="registerSound" h={0} />


### PR DESCRIPTION
This pull request introduces a new custom synthesizer ("organ") to the `superdough` engine and provides extensive documentation and examples to guide developers in creating and using custom synths. The changes include the implementation of the "organ" synth, updates to documentation, and examples showcasing its usage.

### Implementation of the "organ" Synth:
* [`packages/superdough/synth.mjs`](diffhunk://#diff-b9f29109cd95540e3c08b69b895ecd36a4e1b03052ffc878153719b5535b3708R300-R376): Added the "organ" synth, which uses additive synthesis with multiple sine oscillators, an ADSR envelope, and proper node cleanup. The synth is registered with `registerSound` and features detailed inline comments for clarity.

### Documentation Updates:
* [`.cursor/rules/workflows/adding-synths.mdc`](diffhunk://#diff-b6e1135dc8a700ef3b5114d5a85b7d5a9bbeb805bb1e8ca2531b2f401a4fbcbdR1-R83): Added a step-by-step guide for adding new synths, including environment setup, WebAudio graph implementation, testing, and documentation requirements.
* [`website/src/pages/learn/custom-synth.mdx`](diffhunk://#diff-4ed2aaf9e6adf2435e9ac19fbf03ef9a6e4c24a1f05571eeb586291feef7a334R1-R34): Created a new guide explaining how to create and register custom synths with `superdough`, using the "organ" synth as an example.
* [`packages/superdough/README.md`](diffhunk://#diff-9e93d238e6b70618768c5536ec41950785d030c1b5bf381647ee489f834efda8R166-R181): Updated the README with an example of using the "organ" synth and instructions for extending the synth list.

### Examples and Templates:
* [`.github/prompts/custom-synth.prompt.md`](diffhunk://#diff-623ceadb88356475c0033f9c41be25655ac9133dfceb4b74a6132423b7ce17deR1-R65): Added a prompt template for creating custom synths, outlining the implementation steps and providing a skeleton code example.
* [`examples/superdough/index.html`](diffhunk://#diff-c14b3d277bb68c1c52265d1e9405289e5f824ca1489cfa1f381d4a24b8a104fcR27-R28): Updated the example to demonstrate playing the "organ" synth.

### Workflow Example:
* [`claude/workflows/custom-synth.md`](diffhunk://#diff-c8d5440f9d8c14416a0402b42e04056ad78ba5617863076ac943654304559d22R1-R81): Added a workflow example for implementing and registering a custom synth, including a detailed implementation of the "organ" synth.

## Summary
- add instructions for creating custom synths in `.cursor/rules/workflows`

## Testing
- `pnpm test --run packages/core/test/pattern.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_684a730010e08324b6e7a29dc4e3bf1e