### PR TITLE
Add fm4 algorithm-less FM synth

### DIFF
--- a/packages/superdough/README.md
+++ b/packages/superdough/README.md
@@ -177,6 +177,9 @@ registerSynthSounds();
 
 // the organ synth is registered automatically and can be played like this
 superdough({ s: 'organ', note: 'c4', duration: 1 }, 0);
+
+// a 4 operator FM voice is also available
+superdough({ s: 'fm4', note: 'c4', duration: 1 }, 0);
 ```
 
 ## Credits


### PR DESCRIPTION
This pull request introduces a new 4-operator FM synthesizer (`fm4`) to the `superdough` library. The changes include registering the new synth, defining its functionality, and updating the documentation to reflect its availability.

### New Synthesizer Implementation:

* **FM Synthesizer Registration**: Added a new sound type, `fm4`, to the `registerSynthSounds()` function. This includes defining its behavior with customizable parameters such as frequency ratios, amplitude levels, modulation matrix, and ADSR envelope settings. The implementation uses Web Audio API components like oscillators, gain nodes, and a modulation matrix to create a flexible FM synthesis engine. (`packages/superdough/synth.mjs`, [packages/superdough/synth.mjsR377-R456](diffhunk://#diff-b9f29109cd95540e3c08b69b895ecd36a4e1b03052ffc878153719b5535b3708R377-R456))

### Documentation Updates:

* **Readme Update**: Updated the `README.md` to include an example of how to use the new `fm4` synth, demonstrating its usage alongside the existing `organ` synth. (`packages/superdough/README.md`, [packages/superdough/README.mdR180-R182](diffhunk://#diff-9e93d238e6b70618768c5536ec41950785d030c1b5bf381647ee489f834efda8R180-R182))

## Summary
- add `fm4` four-operator FM synth in `synth.mjs`
- document fm4 usage in README

## Testing
- `pnpm test --run packages/core/test/pattern.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_684b140933548324bf43f9580b0b5505